### PR TITLE
get API_URL from process.env, or use default

### DIFF
--- a/frontend-svelte/rollup.config.js
+++ b/frontend-svelte/rollup.config.js
@@ -49,7 +49,7 @@ export default {
       },
     }),
     replace({
-      "process.env.IS_PROD": production,
+      "process.env.API_URL": process.env.API_URL,
     }),
     // we'll extract any component CSS out into
     // a separate file - better for performance

--- a/frontend-svelte/src/constants.js
+++ b/frontend-svelte/src/constants.js
@@ -1,1 +1,1 @@
-export const API_URL = process.env.IS_PROD ? "/api" : "http://localhost:3000"
+export const API_URL = process.env.API_URL || "http://localhost:3000"


### PR DESCRIPTION
With this, `API_URL` can be set for each environment:

* Removes env detection logic from the code (better), following 12-factor app guidelines: https://12factor.net/config
* Note: Each environment **has to have API_URL defined as an environment variable**
* If the env var `API_URL` is `undefined,` the api url in code will default to the development one (`localhost:3000`)

**Important: in Heroku, make sure to add the env var `API_URL` with value `/api`**
