### PR TITLE
pin exact engine versions for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "check": "yarn prettier -c frontend-svelte"
   },
   "engines": {
-    "node": ">=14.17",
-    "yarn": ">=1.22"
+    "node": "14.17.14",
+    "yarn": "1.22.11"
   },
   "routify": {
     "routifyDir": "frontend-svelte/.routify",


### PR DESCRIPTION
* fixes Heroku failing because of "unsafe version ranges"