### PR TITLE
Add env cmd

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# BACKEND =============================================
+
+
+
+
+# FRONTEND ============================================
+
+FRONTEND_APP_API_URL=http://localhost:3000
+FRONTEND_APP_LEAFLET_ACCESS_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 __pycache__
+.env

--- a/frontend-svelte/rollup.config.js
+++ b/frontend-svelte/rollup.config.js
@@ -5,6 +5,13 @@ import resolve from "@rollup/plugin-node-resolve"
 import livereload from "rollup-plugin-livereload"
 import { terser } from "rollup-plugin-terser"
 import css from "rollup-plugin-css-only"
+import { getFrontendEnvVars } from "./utils/getFrontendEnvVars"
+import { getReplacements } from "./utils/getReplacements"
+import { printEnv } from "./utils/printEnv"
+
+const frontendEnvVars = getFrontendEnvVars()
+printEnv(frontendEnvVars)
+const replacements = getReplacements(frontendEnvVars)
 
 const production = !process.env.ROLLUP_WATCH
 
@@ -48,9 +55,7 @@ export default {
         dev: !production,
       },
     }),
-    replace({
-      "process.env.API_URL": `"${process.env.API_URL}"`,
-    }),
+    replace(replacements),
     // we'll extract any component CSS out into
     // a separate file - better for performance
     css({ output: "bundle.css" }),

--- a/frontend-svelte/src/constants.js
+++ b/frontend-svelte/src/constants.js
@@ -1,5 +1,4 @@
-export const API_URL = process.env.API_URL || "http://localhost:3000"
-export const LEAFLET_ACCESS_TOKEN =
-  "pk.eyJ1IjoicHJvamVjdGxpbmthZ2UiLCJhIjoiY2tycGk0ejA2MmQ1cTJucnZiZTRsOXZlYyJ9.YkeSvM4CDDlz9dHlkc7Zuw"
+export const API_URL = process.env.FRONTEND_APP_API_URL
 
-console.log(API_URL)
+export const LEAFLET_ACCESS_TOKEN =
+  process.env.FRONTEND_APP_LEAFLET_ACCESS_TOKEN

--- a/frontend-svelte/utils/getFrontendEnvVars.js
+++ b/frontend-svelte/utils/getFrontendEnvVars.js
@@ -1,0 +1,11 @@
+// Picks all env vars starting with PREFIX
+// and returns a corresponding object
+
+const PREFIX = "FRONTEND_APP_"
+const ENV = process.env
+
+export const getFrontendEnvVars = () =>
+  Object.keys(ENV).reduce((acc, val) => {
+    if (val.startsWith(PREFIX)) acc[val] = ENV[val]
+    return acc
+  }, {})

--- a/frontend-svelte/utils/getReplacements.js
+++ b/frontend-svelte/utils/getReplacements.js
@@ -1,0 +1,7 @@
+// From an object following the format of `process.env`,
+// produces an objects ready to use with rollup plugin-replace
+
+export const getReplacements = (envVars) =>
+  Object.entries(envVars).reduce((acc, [k, v]) => {
+    return { ...acc, [`process.env.${k}`]: `"${v}"` }
+  }, {})

--- a/frontend-svelte/utils/printEnv.js
+++ b/frontend-svelte/utils/printEnv.js
@@ -1,0 +1,9 @@
+export const printEnv = (envVars) => {
+  const entries = Object.entries(envVars)
+
+  console.log("\n= FRONTEND ENV VARS ".padEnd(70, "="))
+  for (const [k, v] of entries) {
+    console.log(` ${k}=${v}`.substring(0, 68))
+  }
+  console.log("\n".padStart(70, "="))
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@rollup/plugin-replace": "^3.0.0",
     "@roxi/routify": "^2.18.2",
+    "env-cmd": "^10.1.0",
     "json-server": "^0.16.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "project-linkage-001",
   "version": "1.0.0",
   "scripts": {
-    "build": "routify -b && yarn run-p build:*",
+    "build": "env-cmd --silent routify -b && yarn run-p build:*",
     "build:css": "yarn sass app/DAS_framework/css/app.scss frontend-svelte/public/build/app.css",
     "build:js": "cd frontend-svelte; rollup -c",
-    "dev": "yarn run-p dev:*",
+    "dev": "env-cmd yarn run-p dev:*",
     "dev:api": "yarn json-server --watch frontend-svelte/db.json",
     "dev:frontend": "cd frontend-svelte; rollup -c -w",
     "dev:routify": "routify",

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,11 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 commander@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
@@ -576,6 +581,15 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.0:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -738,6 +752,14 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1878,6 +1900,11 @@ path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -2243,10 +2270,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.6.1:
   version "1.7.2"
@@ -2665,6 +2704,13 @@ which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
This introduces `env-cmd` for use in the frontend.



## **Important: This introduces some breaking changes**

These environment variables have been renamed:

* `API_URL` renamed to `FRONTEND_APP_API_URL`
* `LEAFLET_ACCESS_TOKEN` renamed to `FRONTEND_APP_LEAFLET_ACCESS_TOKEN`

Please make sure to update Heroku accordingly.

## Usage

1. copy `.env.example` as new file `.env`
2. inside `.env`: fill-in empty values (api keys, secrets, ...)
3. inside: `.env`: this file is not versioned, you can change any values as you wish as it only affects your local environment

## Notes

* env-cmd and its `.env` files are to be used only in local environments (development, test)
* in hosted environments (staging, production), the env vars are read from the environment itself as before

